### PR TITLE
run ci tests only on node 4 for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 script:
   - npm run test
-  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sauce; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "4" ]; then npm run test:sauce; fi

--- a/test/integration/wdio.sauce-conf.js
+++ b/test/integration/wdio.sauce-conf.js
@@ -21,7 +21,7 @@ exports.config = {
   specs: [
     path.join(__dirname, '/specs/desktop.test.js')
   ],
-  maxInstances: 2,
+  maxInstances: 4,
   capabilities: [
     capabilities({
       browserName: 'firefox',


### PR DESCRIPTION
It's enough to run ci tests only once. All other versions are already covered by unit tests.