### PR TITLE
lock firefox version to latest stable

### DIFF
--- a/test/integration/wdio.sauce-conf.js
+++ b/test/integration/wdio.sauce-conf.js
@@ -26,6 +26,7 @@ exports.config = {
     capabilities({
       browserName: 'firefox',
       platform: 'Windows 7',
+      version: '46.0',
       screenResolution: '1920x1200',
     }),
     capabilities({
@@ -59,6 +60,7 @@ exports.config = {
     capabilities({
       browserName: 'firefox',
       platform: 'OS X 10.11',
+      version: '46.0',
       screenResolution: '1920x1440',
     }),
     capabilities({


### PR DESCRIPTION
Firefox 47 fails when we try to access global variables like window or document. Bug is already fixed in latest firefox but saucelabs needs some time to update all instances of firefox  (see [here](https://support.saucelabs.com/customer/portal/questions/16341558-problem-with-executing-script-via-webdriver-in-firefox-47)).

As a workaround let's switch to latest stable version until firefox 47 works properly...
