### PR TITLE
Added !important suffix for styles

### DIFF
--- a/src/modules/beforeScreenshot.js
+++ b/src/modules/beforeScreenshot.js
@@ -18,7 +18,7 @@ export default async function beforeScreenshot(browser, options) {
   // hide elements
   if (Array.isArray(options.hide) && options.hide.length) {
     log('hide the following elements: %s', options.hide.join(', '));
-    await browser.selectorExecute(options.hide, modifyElements, 'visibility', 'hidden');
+    await browser.selectorExecute(options.hide, modifyElements, 'opacity', '0');
   }
 
   // remove elements

--- a/src/scripts/modifyElements.js
+++ b/src/scripts/modifyElements.js
@@ -9,7 +9,14 @@ export default function modifyElements() {
   args.splice(-2);
   for (var i = 0; i < args.length; ++i) {
     for (var j = 0; j < args[i].length; ++j) {
-      args[i][j].style[style] = value;
+      var element = args[i][j];
+
+      try {
+         element.style.setProperty(style, value, 'important');
+      }
+      catch (error) {
+         element.setAttribute('style', element.style.cssText + style + ':' + value + '!important;');
+      }
     }
   }
 }


### PR DESCRIPTION
#### visibility -> opacity

`visibility` occupies space and you can click on element behind it. Can be overridden via side-effect in nested blocks. 
`opacity` occupies space, you don't see it but you can not click on elements behind it.

#### !important

When an important rule is used on a style declaration, this declaration overrides any other declarations.

All these changes are working on my project. 

@zinserjan, can you merge it?