### PR TITLE
use opacity:0 instead of visibility:hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ available:
   that queries one or multiple elements or you can define x and y values which stretch a rectangle or polygon
 
 * **hide** `String[]`<br>
-  hides all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `visibility: hidden`)
+  hides all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `opacity: 0`)
 
 * **remove** `String[]`<br>
   removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)

--- a/src/modules/afterScreenshot.js
+++ b/src/modules/afterScreenshot.js
@@ -9,7 +9,7 @@ export default async function afterScreenshot(browser, options) {
   // show elements
   if (Array.isArray(options.hide) && options.hide.length) {
     log('show the following elements again: %s', options.hide.join(', '));
-    await browser.selectorExecute(options.hide, modifyElements, 'visibility', '');
+    await browser.selectorExecute(options.hide, modifyElements, 'opacity', '');
   }
 
   // add elements again

--- a/src/modules/beforeScreenshot.js
+++ b/src/modules/beforeScreenshot.js
@@ -18,7 +18,7 @@ export default async function beforeScreenshot(browser, options) {
   // hide elements
   if (Array.isArray(options.hide) && options.hide.length) {
     log('hide the following elements: %s', options.hide.join(', '));
-    await browser.selectorExecute(options.hide, modifyElements, 'visibility', 'hidden');
+    await browser.selectorExecute(options.hide, modifyElements, 'opacity', '0');
   }
 
   // remove elements

--- a/test/fixture/web/integration/element-modifier.html
+++ b/test/fixture/web/integration/element-modifier.html
@@ -13,7 +13,7 @@
     <div class="wrapper">
       <div class="group display-block-important">
         <div class="box red"></div>
-        <div class="box blue"></div>
+        <div class="box blue visibility-visible-important"></div>
         <div class="box green"></div>
       </div>
       <div class="box pink"></div>


### PR DESCRIPTION
from @monolithed (#26)

> #### visibility -> opacity
> 
> `visibility` occupies space and you can click on element behind it. Can be overridden via side-effect in nested blocks. 
> `opacity` occupies space, you don't see it but you can not click on elements behind it.

Adjusted tests + other occurrences of visibility. 