### PR TITLE
use Firefox & Chrome for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
+sudo: required # to make Chrome available
+dist: trusty  # to get new Chrome version
 language: node_js
 node_js:
   - "0.12"
   - "4"
   - "5"
+
+addons:
+  firefox: "46.01"
 
 env:
   global:
@@ -11,9 +16,15 @@ env:
     - GRAPHICSMAGICK=true
     - GRAPHICSMAGICK=false
 
+before_script:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
 before_install:
   - if [ "$GRAPHICSMAGICK" = "true" ] ; then sudo apt-get update && sudo apt-get install graphicsmagick; fi
 
 script:
   - npm run test
+  - if [ "${TRAVIS_NODE_VERSION}" = "4" ]; then npm run test:travis; fi
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "4" ] && [ "$GRAPHICSMAGICK" = "true" ]; then npm run test:sauce; fi

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "npm run clean && mocha --compilers js:babel-register --recursive test/unit",
     "test:local": "npm run clean && wdio ./test/integration/wdio.local-conf.js",
     "test:sauce": "npm run clean && wdio ./test/integration/wdio.sauce-conf.js",
+    "test:travis": "npm run clean && wdio ./test/integration/wdio.travis-conf.js",
     "server": "http-server test/fixture/web -p 8080",
     "deploy-integration-tests": "gh-pages -d test/fixture/web"
   },

--- a/test/integration/wdio.travis-conf.js
+++ b/test/integration/wdio.travis-conf.js
@@ -1,0 +1,41 @@
+require("babel-register");
+
+var path = require('path');
+
+exports.config = {
+  specs: [
+    path.join(__dirname, '/specs/desktop.test.js')
+  ],
+  capabilities: [
+    {
+      browserName: 'chrome',
+      chromeOptions: {
+        args: [
+          '--no-sandbox'
+        ]
+      }
+    },
+    {
+      browserName: 'firefox'
+    }
+  ],
+  sync: false,
+  logLevel: 'silent',
+  coloredLogs: true,
+  baseUrl: 'http://zinserjan.github.io/wdio-screenshot/integration',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
+  connectionRetryCount: 3,
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    compilers: [
+      'js:babel-register'
+    ],
+  },
+  before: function() {
+    require('../../src').init(browser, {})
+  },
+  services: ['selenium-standalone'],
+}


### PR DESCRIPTION
At the moment integration tests against real browsers are only executed on pushes to this repository. That's due to [security restrictions ](https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions)to avoid stealing of saucelabs credentials by malicious forks. This is why I have to test each PR from a fork by hand or push them to this repository...

But the good news is that Travis CI supports selenium testing for Chrome & Firefox. So we can test against these browsers for PR's and keep using saucelabs for normal pushes  :sunglasses: