### PR TITLE
use Firefox, Chrome & Internet Explorer for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,20 @@ install:
   - if %GRAPHICSMAGICK%==true appveyor-retry appveyor DownloadFile http://downloads.sourceforge.net/graphicsmagick/GraphicsMagick-1.3.20-Q8-win32-dll.exe
   - if %GRAPHICSMAGICK%==true GraphicsMagick-1.3.20-Q8-win32-dll.exe /SP /VERYSILENT /NORESTART /NOICONS /DIR=%CD%\gm
   - if %GRAPHICSMAGICK%==true set PATH=%CD%\gm;%PATH%
-  # Get the latest stable version of Node 0.STABLE.latest
+  # install chrome & firefox
+  - if "%nodejs_version%"=="4" choco install googlechrome
+  - if "%nodejs_version%"=="4" choco install firefox -version 46.0.1
+  # Get the wanted version of Node
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
   - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install || (timeout 30 && npm install)
+  # change resolution
+  - ps: Set-DisplayResolution -Width 1920 -Height 1080 -Force
+  # apply reg hack so that the driver can maintain a connection to the instance of Internet Explorer it creates
+  - REG ADD "HKLM\SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
+  - REG ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
 
 # Post-install test scripts.
 test_script:
@@ -35,7 +43,8 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - cmd: npm run test
+  - npm run test
+  - if "%nodejs_version%"=="4" npm run test:appveyor
 
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:local": "npm run clean && wdio ./test/integration/wdio.local-conf.js",
     "test:sauce": "npm run clean && wdio ./test/integration/wdio.sauce-conf.js",
     "test:travis": "npm run clean && wdio ./test/integration/wdio.travis-conf.js",
+    "test:appveyor": "npm run clean && wdio ./test/integration/wdio.appveyor-conf.js",
     "server": "http-server test/fixture/web -p 8080",
     "deploy-integration-tests": "gh-pages -d test/fixture/web"
   },

--- a/test/integration/wdio.appveyor-conf.js
+++ b/test/integration/wdio.appveyor-conf.js
@@ -1,0 +1,44 @@
+require("babel-register");
+var path = require('path');
+
+exports.config = {
+  specs: [
+    path.join(__dirname, '/specs/desktop.test.js')
+  ],
+  capabilities: [
+    {
+      browserName: 'chrome'
+    },
+    {
+      browserName: 'firefox'
+    },
+    {
+      browserName: 'internet explorer',
+      version: '11'
+    }
+  ],
+  sync: false,
+  logLevel: 'silent',
+  coloredLogs: true,
+  baseUrl: 'http://zinserjan.github.io/wdio-screenshot/integration',
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
+  connectionRetryCount: 3,
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+    compilers: [
+      'js:babel-register'
+    ],
+  },
+  before: function() {
+    require('../../src').init(browser, {})
+  },
+  services: ['selenium-standalone'],
+  seleniumArgs: {
+    seleniumArgs: [
+      '-Djna.nosys=true'
+    ]
+  }
+}


### PR DESCRIPTION
Basically the same as #29 but for Appveyor CI (Windows). Additionally, we can also test against Internet Explorer 11.

That was a very frustrating and time-consuming PR cause of IE quirks with over 35 failed builds.
Summary of problems:
* display resolution must be bigger than the wanted screenshot width (finally found a way to set display resolution for Appveyors VM's ) 
* IE Webdriver lost the connection to the IE instance (Registry hack necessary)
* weird error: `ERROR: Can't obtain updateLastError method for class com.sun.jna.Native` (fixable with `-Djna.nosys=true`)

Helpful Links for the future:
* [Internet Explorer Selenium Configuration](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-configuration)
* [ERROR: Can't obtain updateLastError method for class com.sun.jna.Native](https://github.com/angular/protractor/issues/2728#issuecomment-182169617)