### PR TITLE
use local http server to serve static html/test files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,14 @@ env:
     - GRAPHICSMAGICK=true
     - GRAPHICSMAGICK=false
 
+before_install:
+  - if [ "$GRAPHICSMAGICK" = "true" ] ; then sudo apt-get update && sudo apt-get install graphicsmagick; fi
+
 before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-
-before_install:
-  - if [ "$GRAPHICSMAGICK" = "true" ] ; then sudo apt-get update && sudo apt-get install graphicsmagick; fi
+  - if [ "${TRAVIS_NODE_VERSION}" = "4" ]; then npm run server & fi
 
 script:
   - npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,11 @@ install:
   - REG ADD "HKLM\SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
   - REG ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
 
-# Post-install test scripts.
+# scripts to run before tests
+before_test:
+- ps: $ServerProcess = Start-Process npm -ArgumentList "run server" -PassThru
+
+# test scripts
 test_script:
   # Output useful info for debugging.
   - node --version
@@ -45,6 +49,10 @@ test_script:
   # run tests
   - npm run test
   - if "%nodejs_version%"=="4" npm run test:appveyor
+
+# scripts to run after tests
+after_test:
+- ps: Stop-Process -Id $ServerProcess.Id
 
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:sauce": "npm run clean && wdio ./test/integration/wdio.sauce-conf.js",
     "test:travis": "npm run clean && wdio ./test/integration/wdio.travis-conf.js",
     "test:appveyor": "npm run clean && wdio ./test/integration/wdio.appveyor-conf.js",
-    "server": "http-server test/fixture/web -p 8080",
+    "server": "http-server test/fixture/web -p 3000",
     "deploy-integration-tests": "gh-pages -d test/fixture/web"
   },
   "repository": {

--- a/test/integration/wdio.appveyor-conf.js
+++ b/test/integration/wdio.appveyor-conf.js
@@ -20,7 +20,7 @@ exports.config = {
   sync: false,
   logLevel: 'silent',
   coloredLogs: true,
-  baseUrl: 'http://zinserjan.github.io/wdio-screenshot/integration',
+  baseUrl: 'http://localhost:3000/integration',
   waitforTimeout: 10000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,

--- a/test/integration/wdio.local-conf.js
+++ b/test/integration/wdio.local-conf.js
@@ -14,7 +14,7 @@ exports.config = {
   sync: false,
   logLevel: 'silent',
   coloredLogs: true,
-  baseUrl: 'http://127.0.0.1:8080/integration',
+  baseUrl: 'http://localhost:3000/integration',
   waitforTimeout: 10000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,

--- a/test/integration/wdio.sauce-conf.js
+++ b/test/integration/wdio.sauce-conf.js
@@ -3,12 +3,18 @@ require("babel-register");
 var path = require('path');
 
 function capabilities(caps) {
-  if (typeof process.env.TRAVIS_BUILD_NUMBER !== 'undefined') {
-    caps['build'] = process.env.TRAVIS_BUILD_NUMBER;
-  };
 
-  if(process.env.CONTINUOUS_INTEGRATION === 'true') {
+  if (process.env.CONTINUOUS_INTEGRATION === 'true') {
     caps['name'] = 'wdio-screenshot integration test';
+
+    if (typeof process.env.TRAVIS_BUILD_NUMBER !== 'undefined') {
+      caps['build'] = process.env.TRAVIS_BUILD_NUMBER;
+    };
+
+    if (typeof process.env.TRAVIS_JOB_NUMBER !== 'undefined') {
+      caps['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
+    };
+
   } else {
     caps['name'] = 'wdio-screenshot development test';
   }
@@ -72,11 +78,10 @@ exports.config = {
   sync: false,
   logLevel: 'silent',
   coloredLogs: true,
-  baseUrl: 'http://zinserjan.github.io/wdio-screenshot/integration',
+  baseUrl: 'http://localhost:3000/integration',
   waitforTimeout: 30000,
   connectionRetryTimeout: 180000,
   connectionRetryCount: 3,
-
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
@@ -91,5 +96,8 @@ exports.config = {
   services: ['sauce'],
   user: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY,
-  sauceConnect: false,
+  sauceConnect: true,
+  sauceConnectOpts: {
+    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || null,
+  },
 }

--- a/test/integration/wdio.travis-conf.js
+++ b/test/integration/wdio.travis-conf.js
@@ -22,7 +22,7 @@ exports.config = {
   sync: false,
   logLevel: 'silent',
   coloredLogs: true,
-  baseUrl: 'http://zinserjan.github.io/wdio-screenshot/integration',
+  baseUrl: 'http://localhost:3000/integration',
   waitforTimeout: 10000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,


### PR DESCRIPTION
At the moment all html test files are delivered via gh-pages. That's not an option for developing new features or fixing bugs when someone have to modify the html files.

I did this initially as a quick & dirty solution for development purposes to work around some timeout problems with sauce connect. But that shouldn't affect CI builds ...