### PR TITLE
Farewell to Node.js v5! Move on to Node.js v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 node_js:
   - "0.12"
   - "4"
-  - "5"
+  - "6"
 
 addons:
   firefox: "46.01"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
       GRAPHICSMAGICK: true
     - nodejs_version: "4"
       GRAPHICSMAGICK: false
-    - nodejs_version: "5"
+    - nodejs_version: "6"
       GRAPHICSMAGICK: true
-    - nodejs_version: "5"
+    - nodejs_version: "6"
       GRAPHICSMAGICK: false
 
 # Install scripts. (runs after repo cloning)


### PR DESCRIPTION
> You may have missed it but at the end of June, the Node.js project said a final farewell to version 5. There will be no more patches, critical or otherwise, for this branch. 
...
> v6 which is still a Current release, due to become our second LTS release in October where its life will continue under Active LTS and Maintenance until April 2019.

more [here](https://nodejs.org/en/blog/community/v5-to-v7/)

I think we can also stop supporting v5 and move on to the new LTS version.