### PR TITLE
Remove ES6 default parameter for virtualScroll

### DIFF
--- a/src/modules/makeAreaScreenshot.js
+++ b/src/modules/makeAreaScreenshot.js
@@ -41,7 +41,7 @@ export default async function makeAreaScreenshot(browser, startX, startY, endX, 
       const { x, y, indexX, indexY } = screenshotStrategy.getScrollPosition();
       log('scroll to coordinates x: %s, y: %s for index x: %s, y: %s', x, y, indexX, indexY);
 
-      await browser.execute(virtualScroll, x, y);
+      await browser.execute(virtualScroll, x, y, false);
       await browser.pause(100);
 
       const filePath = path.join(dir, `${indexY}-${indexX}.png`);

--- a/src/scripts/virtualScroll.js
+++ b/src/scripts/virtualScroll.js
@@ -1,5 +1,5 @@
 
-export default function virtualScroll(x, y, remove = false) {
+export default function virtualScroll(x, y, remove) {
   const w = x === 0 ? 0 : -1 * x;
   const h = y === 0 ? 0 : -1 * y;
 


### PR DESCRIPTION
Firefox with Marionette driver sets the remove parameter always to a truthy value when the parameter is not given. Maybe a Marionette bug..

This change is necessary for #40 to scroll the page properly in firefox otherwise it sticks always at the top.