### PR TITLE
Drop support of node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required # to make Chrome available
 dist: trusty  # to get new Chrome version
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,6 @@ environment:
   global:
       DEBUG: "wdio-screenshot:*"
   matrix:
-    - nodejs_version: "0.12"
-      GRAPHICSMAGICK: true
-    - nodejs_version: "0.12"
-      GRAPHICSMAGICK: false
     - nodejs_version: "4"
       GRAPHICSMAGICK: true
     - nodejs_version: "4"

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "wdio-sauce-service": "^0.2.2",
     "wdio-selenium-standalone-service": "0.0.5",
     "webdriverio": "^4.0.9"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
LTS for node 0.12 will end this year and some other plugins like `babel-plugin-lodash` dropped support without a breaking change. That's why our node 0.12 builds started to fail and I think it's a the right time to drop node 0.12.

As we have not reached `1.0.0` it's ok to publish this as a minor (for versions below 1.0.0 minor is equal to major).