### PR TITLE
Lock webdriverio version in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "wdio-mocha-framework": "^0.3.2",
     "wdio-sauce-service": "^0.2.2",
     "wdio-selenium-standalone-service": "0.0.5",
-    "webdriverio": "^4.0.9"
+    "webdriverio": "~4.2.16"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
CI fails cause of some issues with webdriverio/wdio-sauce-service#13 and webdriverio/webdriverio#1731.

As a workaround we'll use the version lock until the issues are solved. 