### PR TITLE
Use latest chrome on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ env:
 
 before_install:
   - if [ "$GRAPHICSMAGICK" = "true" ] ; then sudo apt-get update && sudo apt-get install graphicsmagick; fi
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
 
 before_script:
-  - export CHROME_BIN=chromium-browser
+  - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - if [ "${TRAVIS_NODE_VERSION}" = "4" ]; then npm run server & fi


### PR DESCRIPTION
`wdio-selenium-standalone-service` downloads the chromedriver for the latest version and travis ci does not have the latest version yet.

This fixes the following error:
```
ERROR: unknown error: Chrome version must be >= 53.0.2785.0
```