### PR TITLE
Reduce appveyor build time

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ install:
   - if %GRAPHICSMAGICK%==true appveyor-retry appveyor DownloadFile http://downloads.sourceforge.net/graphicsmagick/GraphicsMagick-1.3.20-Q8-win32-dll.exe
   - if %GRAPHICSMAGICK%==true GraphicsMagick-1.3.20-Q8-win32-dll.exe /SP /VERYSILENT /NORESTART /NOICONS /DIR=%CD%\gm
   - if %GRAPHICSMAGICK%==true set PATH=%CD%\gm;%PATH%
-  # install chrome & firefox
-  - choco install googlechrome
-  - choco install firefox -version 46.0.1
   # Get the wanted version of Node
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,6 @@ environment:
   global:
       DEBUG: "wdio-screenshot:*"
   matrix:
-    - nodejs_version: "4"
-      GRAPHICSMAGICK: true
-    - nodejs_version: "4"
-      GRAPHICSMAGICK: false
     - nodejs_version: "6"
       GRAPHICSMAGICK: true
     - nodejs_version: "6"
@@ -19,8 +15,8 @@ install:
   - if %GRAPHICSMAGICK%==true GraphicsMagick-1.3.20-Q8-win32-dll.exe /SP /VERYSILENT /NORESTART /NOICONS /DIR=%CD%\gm
   - if %GRAPHICSMAGICK%==true set PATH=%CD%\gm;%PATH%
   # install chrome & firefox
-  - if "%nodejs_version%"=="4" choco install googlechrome
-  - if "%nodejs_version%"=="4" choco install firefox -version 46.0.1
+  - choco install googlechrome
+  - choco install firefox -version 46.0.1
   # Get the wanted version of Node
   - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
@@ -44,7 +40,7 @@ test_script:
   - npm --version
   # run tests
   - npm run test
-  - if "%nodejs_version%"=="4" npm run test:appveyor
+  - npm run test:appveyor
 
 # scripts to run after tests
 after_test:

--- a/test/integration/wdio.appveyor-conf.js
+++ b/test/integration/wdio.appveyor-conf.js
@@ -7,12 +7,6 @@ exports.config = {
   ],
   capabilities: [
     {
-      browserName: 'chrome'
-    },
-    {
-      browserName: 'firefox'
-    },
-    {
       browserName: 'internet explorer',
       version: '11'
     }


### PR DESCRIPTION
This PR reduces the build time of Appveyor CI:

- test only Node v6
- stop testing Chrome & Firefox (already tested by Saucelabs & Travis)
- test only unit tests & integrations tests for IE