### PR TITLE
Added skipPageHeightSetter option to circumvent #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ available:
 * **remove** `String[]`<br>
   removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)
 
+* **skipPageHeightSetter** `bool` <br>
+  bypasses the fix introduced in #25, as it can add weird behavior to some pages
+
 ## Use GraphicsMagick
 wdio-screenshot uses [GraphicsMagick](http://www.graphicsmagick.org/) for image processing when available. Without GraphicsMagick installed, wdio-screenshot fallbacks to [Jimp](https://github.com/oliver-moran/jimp) - a image processing library written in JS.
 

--- a/src/modules/makeAreaScreenshot.js
+++ b/src/modules/makeAreaScreenshot.js
@@ -24,7 +24,7 @@ async function storeScreenshot(browser, screenDimensions, cropDimensions, base64
   await saveBase64Image(filePath, croppedBase64Screenshot);
 }
 
-export default async function makeAreaScreenshot(browser, startX, startY, endX, endY) {
+export default async function makeAreaScreenshot(browser, startX, startY, endX, endY, options) {
   log('requested a screenshot for the following area: %j', {startX, startY, endX, endY});
 
   const screenDimensions = (await browser.execute(getScreenDimensions)).value;
@@ -44,8 +44,10 @@ export default async function makeAreaScreenshot(browser, startX, startY, endX, 
     const cropImages = [];
     const screenshotPromises = [];
 
-    log('set page height to %s px', screenDimension.getDocumentHeight());
-    await browser.execute(pageHeight, `${screenDimension.getDocumentHeight()}px`);
+    if (!options.skipPageHeightSetter) {
+      log('set page height to %s px', screenDimension.getDocumentHeight());
+      await browser.execute(pageHeight, `${screenDimension.getDocumentHeight()}px`);
+    }
 
     let loop = false;
     do {
@@ -82,8 +84,10 @@ export default async function makeAreaScreenshot(browser, startX, startY, endX, 
         return mergedBase64Screenshot;
       }),
       Promise.resolve().then(async() => {
-        log('reset page height');
-        await browser.execute(pageHeight, '');
+        if (!options.skipPageHeightSetter) {
+          log('reset page height');
+          await browser.execute(pageHeight, '');
+        }
 
         log('revert scroll to x: %s, y: %s', 0, 0);
         await browser.execute(virtualScroll, 0, 0, true);

--- a/src/modules/makeDocumentScreenshot.js
+++ b/src/modules/makeDocumentScreenshot.js
@@ -21,7 +21,7 @@ export default async function makeDocumentScreenshot(browser, options = {}) {
   const screenDimension = new ScreenDimension(screenDimensions, browser);
 
   // make screenshot of area
-  const base64Image = await makeAreaScreenshot(browser, 0, 0, screenDimension.getDocumentWidth(), screenDimension.getDocumentHeight());
+  const base64Image = await makeAreaScreenshot(browser, 0, 0, screenDimension.getDocumentWidth(), screenDimension.getDocumentHeight(), options);
 
   // show scrollbars, show & add elements
   await afterScreenshot(browser, options);

--- a/src/modules/makeElementScreenshot.js
+++ b/src/modules/makeElementScreenshot.js
@@ -21,7 +21,7 @@ export default async function makeElementScreenshot(browser, elementSelector, op
   const boundingRect = groupBoundingRect(boundingRects);
 
   // make screenshot of area
-  const base64Image = await makeAreaScreenshot(browser, boundingRect.left, boundingRect.top, boundingRect.right, boundingRect.bottom);
+  const base64Image = await makeAreaScreenshot(browser, boundingRect.left, boundingRect.top, boundingRect.right, boundingRect.bottom, options);
 
   // show scrollbars, show & add elements
   await afterScreenshot(browser, options);

--- a/src/modules/makeViewportScreenshot.js
+++ b/src/modules/makeViewportScreenshot.js
@@ -27,7 +27,7 @@ export default async function makeViewportScreenshot(browser, options = {}) {
   const screenDimension = new ScreenDimension(screenDimensions, browser);
 
   // make screenshot of area
-  const base64Image = await makeAreaScreenshot(browser, startX, startY, screenDimension.getViewportWidth(), screenDimension.getViewportHeight());
+  const base64Image = await makeAreaScreenshot(browser, startX, startY, screenDimension.getViewportWidth(), screenDimension.getViewportHeight(), options);
 
   // show scrollbars, show & add elements
   await afterScreenshot(browser, options);


### PR DESCRIPTION
I was seeing some weird issues on pages, and commenting out the pageHeight command seemed to solve it. 

Example page: https://www.mcdonalds.com/us/en-us.html
On this example page, the entire footer would disappear when run on Chrome-Windows 10-Latest
Commenting out the pageHeight command stopped the issue, but brings the whitespace back to the bottom of the page, which is a compromise worth having in order to capture the footer.